### PR TITLE
Fixes #4. Explicitly building liba{catch2wmain}

### DIFF
--- a/catch2-examples/examples/buildfile
+++ b/catch2-examples/examples/buildfile
@@ -1,4 +1,4 @@
-import catch2_lib = catch2%lib{catch2wmain}
+import catch2_lib = catch2%liba{catch2wmain}
 import catch2_lib += catch2%lib{catch2}
 
 single_file_srcs    = 010-TestCase \

--- a/catch2-examples/manifest
+++ b/catch2-examples/manifest
@@ -1,6 +1,6 @@
 : 1
 name: catch2-examples
-version: 3.1.1
+version: 3.1.1+1
 project: catch2
 summary: Catch2 Examples
 license: BSL-1.0

--- a/catch2-tests/extratests/buildfile
+++ b/catch2-tests/extratests/buildfile
@@ -1,4 +1,4 @@
-import catch2_lib = catch2%lib{catch2wmain}
+import catch2_lib = catch2%liba{catch2wmain}
 import catch2_lib += catch2%lib{catch2}
 
 ./: exe{PrefixedMacros}: cxx{X01-PrefixedMacros} $catch2_lib testscript{PrefixedMacros}

--- a/catch2-tests/manifest
+++ b/catch2-tests/manifest
@@ -1,6 +1,6 @@
 : 1
 name: catch2-tests
-version: 3.1.1
+version: 3.1.1+1
 project: catch2
 summary: Catch2 test package
 license: BSL-1.0

--- a/catch2-tests/selftest/buildfile
+++ b/catch2-tests/selftest/buildfile
@@ -1,5 +1,5 @@
 import intf_libs = catch2%lib{catch2}
-import intf_libs =+ catch2%lib{catch2wmain}
+import intf_libs =+ catch2%liba{catch2wmain}
 
 
 ./: exe{selftest}: {hxx cxx}{**} $intf_libs testscript Misc/file{*.input}

--- a/catch2/manifest
+++ b/catch2/manifest
@@ -1,6 +1,6 @@
 : 1
 name: catch2
-version: 3.1.1
+version: 3.1.1+1
 summary: Catch2 is a multi-paradigm test framework for C++. which also supports Objective-C (and maybe C). It is primarily distributed as a single header file, although certain extensions may require additional headers.
 license: BSL-1.0
 description-file: README.md

--- a/catch2/src/buildfile
+++ b/catch2/src/buildfile
@@ -8,9 +8,7 @@ lib{catch2}: def{catch2}: include = ($cxx.target.system == 'win32-msvc')
 def{catch2}: libul{catch2}
 
 # Is this really needed for main function?
-lib{catch2wmain}: libul{catch2wmain}: catch2/internal/cxx{catch_main} lib{catch2}
-lib{catch2wmain}: def{catch2wmain}: include = ($cxx.target.system == 'win32-msvc')
-def{catch2wmain}: libul{catch2wmain}
+liba{catch2wmain}: catch2/internal/cxx{catch_main} lib{catch2}
 
 
 # Build options.
@@ -28,8 +26,8 @@ objs{*}: cxx.poptions += -DCATCH_CONFIG_SHARED_LIBRARY -DCatch2_EXPORTS
 libs{catch2}: cxx.export.poptions += -DCATCH_CONFIG_SHARED_LIBRARY
 liba{catch2}: cxx.export.poptions += -DCATCH_CONFIG_STATIC
 
-if($cxx.target.system == 'win32-msvc')
-  lib{catch2wmain}: cxx.export.loptions += "/INCLUDE:main"
+# if($cxx.target.system == 'win32-msvc')
+#   lib{catch2wmain}: cxx.export.loptions += "/INCLUDE:main"
 
 liba{catch2wmain}:
 {
@@ -37,7 +35,7 @@ liba{catch2wmain}:
   bin.whole = true
 }
 
-./: lib{catch2} lib{catch2wmain}
+./: lib{catch2} liba{catch2wmain}
 
 
 # For pre-releases use the complete version to make sure they cannot be used


### PR DESCRIPTION
Explicitly building only liba{catch2wmain}.

The CI task is found here:
https://ci.cppget.org/@8c472674-8b60-4342-ba3b-efe89d381a5c
