### PR TITLE
Upgrade to v3.3.2

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -29,4 +29,5 @@ catch2-tests/selftest/IntrospectiveTests symlink=dir
 catch2-tests/selftest/Misc               symlink=dir
 catch2-tests/selftest/TimingTests        symlink=dir
 catch2-tests/selftest/UsageTests         symlink=dir
+catch2-tests/selftest/helpers            symlink=dir
 catch2-tests/extratests/extras           symlink=dir

--- a/catch2-examples/examples/buildfile
+++ b/catch2-examples/examples/buildfile
@@ -1,4 +1,4 @@
-import catch2_lib = catch2%lib{catch2wmain}
+import catch2_lib = catch2%liba{catch2wmain}
 import catch2_lib += catch2%lib{catch2}
 
 single_file_srcs    = 010-TestCase \

--- a/catch2-examples/manifest
+++ b/catch2-examples/manifest
@@ -1,6 +1,6 @@
 : 1
 name: catch2-examples
-version: 3.1.1
+version: 3.3.2-a.0.z
 project: catch2
 summary: Catch2 Examples
 license: BSL-1.0

--- a/catch2-tests/extratests/.gitignore
+++ b/catch2-tests/extratests/.gitignore
@@ -24,3 +24,4 @@ CustomArgumentsForReporters
 DuplicatedReporterNames
 ListenerCanAskForCapturedStdout
 ListenersGetEventsBeforeReporters
+AllSkipped

--- a/catch2-tests/extratests/DeferredStaticChecks.testscript
+++ b/catch2-tests/extratests/DeferredStaticChecks.testscript
@@ -2,7 +2,9 @@
 $* -r compact >>~%EOM% != 0
 %(
 %.*%
-%)+?
-Failed 1 test case, failed all 3 assertions.
+%)+
+test cases: 1 | 1 failed
+assertions: 3 | 3 failed
+
 
 EOM

--- a/catch2-tests/extratests/X93-AllSkipped.cpp
+++ b/catch2-tests/extratests/X93-AllSkipped.cpp
@@ -1,0 +1,1 @@
+../../upstream/tests/ExtraTests/X93-AllSkipped.cpp

--- a/catch2-tests/extratests/buildfile
+++ b/catch2-tests/extratests/buildfile
@@ -1,4 +1,4 @@
-import catch2_lib = catch2%lib{catch2wmain}
+import catch2_lib = catch2%liba{catch2wmain}
 import catch2_lib += catch2%lib{catch2}
 
 ./: exe{PrefixedMacros}: cxx{X01-PrefixedMacros} $catch2_lib testscript{PrefixedMacros}

--- a/catch2-tests/extratests/buildfile
+++ b/catch2-tests/extratests/buildfile
@@ -74,6 +74,8 @@ if($cxx.id == 'msvc')
 ./: exe{AmalgamatedTestCompilation}: {hxx cxx}{extras/*} cxx{X91-AmalgamatedCatch} testscript{Amulgamated}
 obj{X91-AmalgamatedCatch}: cxx.poptions += "-I$src_base/extras"
 
+./: exe{AllSkipped}: cxx{X93-AllSkipped} $catch2_lib
+
 # On FreeBSD the auto detection of colour mode is not properly detected on console redirect
 # There are colour codes written out which fails regex match
 if($cxx.target.system == 'freebsd')

--- a/catch2-tests/manifest
+++ b/catch2-tests/manifest
@@ -1,6 +1,6 @@
 : 1
 name: catch2-tests
-version: 3.1.1
+version: 3.3.2-a.0.z
 project: catch2
 summary: Catch2 test package
 license: BSL-1.0

--- a/catch2-tests/selftest/buildfile
+++ b/catch2-tests/selftest/buildfile
@@ -1,5 +1,5 @@
 import intf_libs = catch2%lib{catch2}
-import intf_libs =+ catch2%lib{catch2wmain}
+import intf_libs =+ catch2%liba{catch2wmain}
 
 
 ./: exe{selftest}: {hxx cxx}{**} $intf_libs testscript Misc/file{*.input}

--- a/catch2-tests/selftest/buildfile
+++ b/catch2-tests/selftest/buildfile
@@ -3,7 +3,8 @@ import intf_libs =+ catch2%lib{catch2wmain}
 
 
 ./: exe{selftest}: {hxx cxx}{**} $intf_libs testscript Misc/file{*.input}
-cxx.poptions += "-I$src_base/include"
+# cxx.poptions += "-I$src_base/include"
+cxx.poptions += "-I$src_base"
 
 # Need to ensure MSVC uses all strings as utf-8
 # Required for "Broken String test"

--- a/catch2-tests/selftest/helpers
+++ b/catch2-tests/selftest/helpers
@@ -1,0 +1,1 @@
+../../upstream/tests/SelfTest/helpers

--- a/catch2-tests/selftest/testscript
+++ b/catch2-tests/selftest/testscript
@@ -139,7 +139,7 @@ EOM
   %(
   %.*%
   %)+
-  %No test cases matched '___nonexistent_test___'%
+  %No test cases matched '"___nonexistent_test___"'%
   %(
   %.*%
   %)+
@@ -155,6 +155,19 @@ EOM
   : WarnUnmatchedTestSpecFailsWithUnmatchedTestSpec
   $* Tracker, "___nonexistent_test___" --warn UnmatchedTestSpec >- != 0
 
+  : OverrideAllSkipFailure
+  $* "tests can be skipped dynamically at run time" --allow-running-no-tests >-
+
+  : NonMatchingTestSpecIsRoundTrippable
+  $* "this test does not exist" "[nor does this tag]" >>~%EOM% != 0
+  %(
+  %.*%
+  %)+
+  %No test cases matched '"this test does not exist" \[nor does this tag\]'%
+  %(
+  %.*%
+  %)+
+  EOM
   
 } 
 
@@ -225,14 +238,15 @@ $* "#1670 regression check" -c A -r compact >>~%EOM%
 %(
 %.*%
 %)+
-Passed 1 test case with 2 assertions.
+All tests passed (2 assertions in 1 test case)
+
 
 EOM
 
 : VersionCheck
 $* -h >>~%EOM%
 
-%Catch2 v3\.1\.1%
+%Catch2 v3\.3\.2%
 %(
 %.*%
 %)*?
@@ -461,6 +475,66 @@ EOM
    EOM
  }
 
+ : Filters
+ {
+   : console
+   $* [comparisons][string-case] "CaseInsensitiveLess is case insensitive" --reporter console >>~%EOM%
+   %Filters.+\[comparisons\] \[string-case\] "CaseInsensitiveLess is case insensitive"%
+   %(
+   %.*%
+   %)+
+   EOM
+
+   : compact
+   $* [comparisons][string-case] "CaseInsensitiveLess is case insensitive" --reporter compact >>~%EOM%
+   %Filters.+\[comparisons\] \[string-case\] "CaseInsensitiveLess is case insensitive"%
+   %(
+   %.*%
+   %)+
+   EOM
+
+   : JUnit
+   $* [comparisons][string-case] "CaseInsensitiveLess is case insensitive" --reporter JUnit >>~%EOM%
+   %(
+   %.*%
+   %)+
+   %.*filters.+\[comparisons\] \[string-case\] &quot;CaseInsensitiveLess is case insensitive&quot;.*%
+   %(
+   %.*%
+   %)+
+   EOM
+
+   : SonarQube
+   $* [comparisons][string-case] "CaseInsensitiveLess is case insensitive" --reporter SonarQube >>~%EOM%
+   %(
+   %.*%
+   %)+
+   %.*filters.+\[comparisons\] \[string-case\] "CaseInsensitiveLess is case insensitive".*%
+   %(
+   %.*%
+   %)+
+   EOM
+
+   : TAP
+   $* [comparisons][string-case] "CaseInsensitiveLess is case insensitive" --reporter TAP >>~%EOM%
+   %.*filters.+\[comparisons\] \[string-case\] "CaseInsensitiveLess is case insensitive"%
+   %(
+   %.*%
+   %)+
+   EOM
+
+   : XML
+   $* [comparisons][string-case] "CaseInsensitiveLess is case insensitive" --reporter XML >>~%EOM%
+   %(
+   %.*%
+   %)+
+   %.*filters.+\[comparisons\] \[string-case\] &quot;CaseInsensitiveLess is case insensitive&quot;.*%
+   %(
+   %.*%
+   %)+
+   EOM
+ }
+
  : RngSeed
  {
    : console
@@ -509,6 +583,9 @@ EOM
 
    : TAP
    $* "Factorials are computed" --reporter "TAP" --rng-seed 18181818 >>~%EOM%
+   %(
+   %.*%
+   %)+
    %.*18181818.*%
    %(
    %.*%

--- a/catch2/manifest
+++ b/catch2/manifest
@@ -1,6 +1,6 @@
 : 1
 name: catch2
-version: 3.1.1
+version: 3.3.2-a.0.z
 summary: Catch2 is a multi-paradigm test framework for C++. which also supports Objective-C (and maybe C). It is primarily distributed as a single header file, although certain extensions may require additional headers.
 license: BSL-1.0
 description-file: README.md

--- a/catch2/src/buildfile
+++ b/catch2/src/buildfile
@@ -8,9 +8,10 @@ lib{catch2}: def{catch2}: include = ($cxx.target.system == 'win32-msvc')
 def{catch2}: libul{catch2}
 
 # Is this really needed for main function?
-lib{catch2wmain}: libul{catch2wmain}: catch2/internal/cxx{catch_main} lib{catch2}
-lib{catch2wmain}: def{catch2wmain}: include = ($cxx.target.system == 'win32-msvc')
-def{catch2wmain}: libul{catch2wmain}
+# lib{catch2wmain}: libul{catch2wmain}: catch2/internal/cxx{catch_main} lib{catch2}
+# lib{catch2wmain}: def{catch2wmain}: include = ($cxx.target.system == 'win32-msvc')
+# def{catch2wmain}: libul{catch2wmain}
+liba{catch2wmain}: catch2/internal/cxx{catch_main} lib{catch2}
 
 
 # Build options.
@@ -28,8 +29,11 @@ objs{*}: cxx.poptions += -DCATCH_CONFIG_SHARED_LIBRARY -DCatch2_EXPORTS
 libs{catch2}: cxx.export.poptions += -DCATCH_CONFIG_SHARED_LIBRARY
 liba{catch2}: cxx.export.poptions += -DCATCH_CONFIG_STATIC
 
-if($cxx.target.system == 'win32-msvc')
-  lib{catch2wmain}: cxx.export.loptions += "/INCLUDE:main"
+# if($cxx.target.system == 'win32-msvc')
+# {
+#   lib{catch2wmain}: cxx.export.loptions += "/INCLUDE:main"
+#   lib{catch2wmain}: cxx.pkgconfig.lib += "/INCLUDE:main"
+# }
 
 liba{catch2wmain}:
 {
@@ -37,7 +41,7 @@ liba{catch2wmain}:
   bin.whole = true
 }
 
-./: lib{catch2} lib{catch2wmain}
+./: lib{catch2} liba{catch2wmain}
 
 
 # For pre-releases use the complete version to make sure they cannot be used


### PR DESCRIPTION
For some reason v3.1.1 to v3.3.0 seems to have bugs when building on Fedora.
The main point was to missing headers - Not sure why older versions don't build correctly.

Always build `liba{catch2wmain}`. Building `libs{catch2wmain}` is not supported.
This is similar to #5 and fixes #4.